### PR TITLE
Add: jump tests

### DIFF
--- a/Assets/Editor/Tests/GameComponents.meta
+++ b/Assets/Editor/Tests/GameComponents.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f249b7e154f645b3ac519c57683bdff7
+timeCreated: 1745760506

--- a/Assets/Editor/Tests/GameComponents/Wrappers.meta
+++ b/Assets/Editor/Tests/GameComponents/Wrappers.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8b470b9dac3048ea91f1f7d091bd5bc7
+timeCreated: 1745760510

--- a/Assets/Editor/Tests/GameComponents/Wrappers/JumpTestWrapper.cs
+++ b/Assets/Editor/Tests/GameComponents/Wrappers/JumpTestWrapper.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Moq;
+using Platformer.Core;
+using Platformer.Mechanics;
+
+namespace Editor.Tests.GameComponents
+{
+    public class JumpTestWrapper
+    {
+        private readonly PlayerController playerController;
+        private readonly Mock<IPlayerInput> inputMock = new ();
+        private readonly Mock<ISimulationScheduler> schedulerMock = new ();
+
+        public JumpTestWrapper(PlayerController playerController)
+        {
+            this.playerController = playerController;
+            playerController.input = inputMock.Object;
+            playerController.scheduler = schedulerMock.Object;
+        }
+
+        public void SetGrounded(bool grounded)
+        {
+            var groundedProp = typeof(KinematicObject).GetProperty("IsGrounded", BindingFlags.Instance | BindingFlags.NonPublic);
+            groundedProp?.SetValue(playerController, grounded);
+        }
+
+        public void SimulateJumpPressed()
+        {
+            inputMock.Setup(i => i.JumpPressed()).Returns(true);
+            inputMock.Setup(i => i.JumpReleased()).Returns(false);
+        }
+
+        public void SimulateJumpReleased()
+        {
+            inputMock.Setup(i => i.JumpPressed()).Returns(false);
+            inputMock.Setup(i => i.JumpReleased()).Returns(true);
+        }
+
+        public void TickInput()
+        {
+            playerController.HandleInput();
+        }
+
+        public void TickJumpState()
+        {
+            playerController.HandleJumpState();
+        }
+
+        public bool EventScheduled<T>() where T : Simulation.Event
+        {
+            return schedulerMock.Invocations.Any(i =>
+                i.Method.Name == "Schedule" &&
+                i.Method.IsGenericMethod &&
+                i.Method.GetGenericArguments()[0] == typeof(T));
+        }
+    }
+}

--- a/Assets/Editor/Tests/GameComponents/Wrappers/JumpTestWrapper.cs.meta
+++ b/Assets/Editor/Tests/GameComponents/Wrappers/JumpTestWrapper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6e5cc5fe7a144ccf877a66c05866ec90
+timeCreated: 1745760519

--- a/Assets/Editor/Tests/PlayerJumpTests.cs
+++ b/Assets/Editor/Tests/PlayerJumpTests.cs
@@ -1,0 +1,111 @@
+using Editor.Tests.GameComponents;
+using NUnit.Framework;
+using Platformer.Gameplay;
+using Platformer.Mechanics;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class PlayerJumpTests
+{
+    private PlayerController playerController;
+    private JumpTestWrapper tester;
+    
+    [SetUp]
+    public void SetUp()
+    {
+        var gameObject = new GameObject("Player");
+        playerController = gameObject.AddComponent<PlayerController>();
+
+        // add components to avoid null refs during test
+        gameObject.AddComponent<BoxCollider2D>();
+        gameObject.AddComponent<AudioSource>();
+        gameObject.AddComponent<Health>();
+        gameObject.AddComponent<SpriteRenderer>();
+        gameObject.AddComponent<Animator>();
+
+        playerController.Init();
+        tester = new JumpTestWrapper(playerController);
+    }
+    
+    [TearDown]
+    public void TearDown()
+    {
+        playerController = null;
+        tester = null;
+    }
+    
+    /// <summary>
+    /// Use helper method to run until PrepareToJump
+    /// Asserts if expected prep state is still handled correctly
+    /// </summary>
+    [Test]
+    public void PlayerGrounded_PressJump_PreparesToJump()
+    {
+        tester.PrepareJump();
+        
+        Assert.AreEqual(PlayerController.JumpState.PrepareToJump, playerController.jumpState);
+    }
+    
+    /// <summary>
+    /// Use helper to prepare a jump, then tick over once on the jump state
+    /// Assert jumping state is set as expected
+    /// </summary>
+    [Test]
+    public void PlayerPreparesToJump_PressJump_IsJumping()
+    {
+        tester.PrepareJump();
+        
+        tester.TickJumpState();
+        
+        Assert.AreEqual(PlayerController.JumpState.Jumping, playerController.jumpState);
+    }
+    
+    /// <summary>
+    /// Use helper to start jumping
+    /// Manually set grounded as false to simulate being in air then tick over jump state
+    /// Assert the state & jumped event scheduled are linked as expected
+    /// </summary>
+    [Test]
+    public void PlayerJumps_LeavesGround_IsInFlightAndJumped()
+    {
+        tester.StartJump();
+
+        tester.SetGrounded(false);
+        tester.TickJumpState();
+        
+        Assert.AreEqual(PlayerController.JumpState.InFlight, playerController.jumpState);
+        Assert.IsTrue(tester.EventScheduled<PlayerJumped>());
+    }
+    
+    /// <summary>
+    /// Use helper to fully reach the air
+    /// Set grounded true again to simulate being on ground
+    /// Assert the state & landed event scheduled are linked as expected
+    /// </summary>
+    [Test]
+    public void PlayerInFlight_HitsGround_Landed()
+    {
+        tester.ReachInFLight();
+
+        tester.SetGrounded(true);
+        tester.TickJumpState();
+
+        Assert.AreEqual(PlayerController.JumpState.Landed, playerController.jumpState);
+        Assert.IsTrue(tester.EventScheduled<PlayerLanded>());
+    }
+
+    /// <summary>
+    /// Fully go through a jump start to finish
+    /// Tick over a final jump state
+    /// Assert the jump state reverts to grounded correctly
+    /// </summary>
+    [Test]
+    public void PlayerLanded_TransitionsToGrounded()
+    {
+        tester.Land();
+        
+        tester.TickJumpState();
+        
+        Assert.AreEqual(PlayerController.JumpState.Grounded, playerController.jumpState);
+    }
+}

--- a/Assets/Editor/Tests/PlayerJumpTests.cs.meta
+++ b/Assets/Editor/Tests/PlayerJumpTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f5110faeae2aa974e8961b86404feecd

--- a/Assets/Scripts/Mechanics/PlayerController.cs
+++ b/Assets/Scripts/Mechanics/PlayerController.cs
@@ -43,6 +43,11 @@ namespace Platformer.Mechanics
 
         void Awake()
         {
+            Init();
+        }
+
+        public void Init()
+        {
             health = GetComponent<Health>();
             audioSource = GetComponent<AudioSource>();
             collider2d = GetComponent<Collider2D>();

--- a/Assets/Scripts/Mechanics/PlayerController.cs
+++ b/Assets/Scripts/Mechanics/PlayerController.cs
@@ -78,7 +78,7 @@ namespace Platformer.Mechanics
             }
         }
         
-        void HandleJumpState()
+        public void HandleJumpState()
         {
             jump = false;
             switch (jumpState)


### PR DESCRIPTION
Added:

- JumpTestWrapper - Allows repeatable & internal component/unit tests to interact with the player jump functionality
- JumpTests - Unit Tests that run from Unity Test Framework, primarily Editor tests to run outwith the game loop. These cover all JumpStates

Changed:
- PlayerController - Exposed extras for the test functions. I chose public access vs exposing the internals of whole assembly, but for further tests of the game assembly, the latter would be suitable.

