### PR TITLE
Add: death tests

### DIFF
--- a/Assets/RuntimeTests/Core/TestCollisionListener2D.cs
+++ b/Assets/RuntimeTests/Core/TestCollisionListener2D.cs
@@ -1,0 +1,33 @@
+using System;
+using UnityEngine;
+
+namespace RuntimeTests.Core
+{
+    public class TestCollisionListener2D : MonoBehaviour
+    {
+        public event Action<GameObject> OnTriggerEntered;
+        public event Action<GameObject> OnCollisionEntered;
+        
+        public bool Triggered { get; private set; }
+        public bool Collided { get; private set; }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            Triggered = true;
+            OnTriggerEntered?.Invoke(other.gameObject);
+        }
+
+        private void OnCollisionEnter2D(Collision2D other)
+        {
+            Collided = true;
+            OnCollisionEntered?.Invoke(other.gameObject);
+        }
+
+        public enum ContactType
+        {
+            Trigger,
+            Collision,
+            Any
+        }
+    }
+}

--- a/Assets/RuntimeTests/Core/TestCollisionListener2D.cs.meta
+++ b/Assets/RuntimeTests/Core/TestCollisionListener2D.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e359beb3f5d742118910fae068f88829
+timeCreated: 1746006720

--- a/Assets/RuntimeTests/Gameplay/EnemyPathTests.cs
+++ b/Assets/RuntimeTests/Gameplay/EnemyPathTests.cs
@@ -5,7 +5,7 @@ using UnityEngine.TestTools;
 
 namespace RuntimeTests.Gameplay
 {
-    public class EnemyPathTests
+    public class EnemyPathTests : GameplayTestBase
     {
         // A Test behaves as an ordinary method
         [Test]

--- a/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
+++ b/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
@@ -15,6 +15,8 @@ namespace RuntimeTests.Gameplay
         [SetUp]
         public override void SetUp()
         {
+            base.SetUp();
+
             movementHelper = new GameplayMovementHelper(testInput);
             testSpawner = new GameplayTestSpawner();
             waitHelper = new GameplayWaitHelper();
@@ -30,6 +32,8 @@ namespace RuntimeTests.Gameplay
                     Object.DestroyImmediate(obj);
                 }
             }
+            
+            base.TearDown();
         }
     }
 }

--- a/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
+++ b/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
@@ -10,11 +10,12 @@ namespace RuntimeTests.Gameplay
         protected GameplayMovementHelper movementHelper;
         protected GameplayTestSpawner testSpawner;
         protected GameplayWaitHelper waitHelper;
+        protected TestInputProvider testInput = new ();
         
         [SetUp]
         public override void SetUp()
         {
-            movementHelper = new GameplayMovementHelper();
+            movementHelper = new GameplayMovementHelper(testInput);
             testSpawner = new GameplayTestSpawner();
             waitHelper = new GameplayWaitHelper();
         }

--- a/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
+++ b/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using NUnit.Framework;
 using Platformer.Core;
 using Platformer.Mechanics;
@@ -6,6 +7,7 @@ using RuntimeTests.Core;
 using RuntimeTests.Gameplay.Helpers;
 using Unity.Cinemachine;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace RuntimeTests.Gameplay
 {
@@ -21,16 +23,18 @@ namespace RuntimeTests.Gameplay
         public override void SetUp()
         {
             base.SetUp();
-
-            gameController = new GameObject("GameController_TEST").AddComponent<GameController>();
-
+            
             var spawnPoint = new GameObject("Spawn_TEST");
             spawnPoint.transform.position = Vector3.zero;
+
+            var model = new PlatformerModel
+            {
+                spawnPoint = spawnPoint.transform,
+                virtualCamera = new GameObject("VirtualCam_TEST").AddComponent<CinemachineCamera>()
+            };
             
-            var model = new PlatformerModel();
-            model.spawnPoint = spawnPoint.transform;
-            model.virtualCamera = new GameObject("VirtualCam_TEST").AddComponent<CinemachineCamera>();
             Simulation.SetModel(model);
+            gameController = new GameObject("GameController_TEST").AddComponent<GameController>();
             gameController.model = model;
             
             movementHelper = new GameplayMovementHelper(testInput);
@@ -41,6 +45,8 @@ namespace RuntimeTests.Gameplay
         [TearDown]
         public override void TearDown()
         {
+            Simulation.ClearPools();
+
             foreach (var obj in Object.FindObjectsByType<GameObject>(FindObjectsInactive.Include, FindObjectsSortMode.None))
             {
                 if (obj.scene.IsValid() && obj.scene.isLoaded)
@@ -48,7 +54,6 @@ namespace RuntimeTests.Gameplay
                     Object.DestroyImmediate(obj);
                 }
             }
-
             base.TearDown();
         }
     }

--- a/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
+++ b/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
@@ -1,6 +1,10 @@
 using NUnit.Framework;
+using Platformer.Core;
+using Platformer.Mechanics;
+using Platformer.Model;
 using RuntimeTests.Core;
 using RuntimeTests.Gameplay.Helpers;
+using Unity.Cinemachine;
 using UnityEngine;
 
 namespace RuntimeTests.Gameplay
@@ -11,12 +15,24 @@ namespace RuntimeTests.Gameplay
         protected GameplayTestSpawner testSpawner;
         protected GameplayWaitHelper waitHelper;
         protected TestInputProvider testInput = new ();
+        protected GameController gameController;
         
         [SetUp]
         public override void SetUp()
         {
             base.SetUp();
 
+            gameController = new GameObject("GameController_TEST").AddComponent<GameController>();
+
+            var spawnPoint = new GameObject("Spawn_TEST");
+            spawnPoint.transform.position = Vector3.zero;
+            
+            var model = new PlatformerModel();
+            model.spawnPoint = spawnPoint.transform;
+            model.virtualCamera = new GameObject("VirtualCam_TEST").AddComponent<CinemachineCamera>();
+            Simulation.SetModel(model);
+            gameController.model = model;
+            
             movementHelper = new GameplayMovementHelper(testInput);
             testSpawner = new GameplayTestSpawner();
             waitHelper = new GameplayWaitHelper();
@@ -32,7 +48,7 @@ namespace RuntimeTests.Gameplay
                     Object.DestroyImmediate(obj);
                 }
             }
-            
+
             base.TearDown();
         }
     }

--- a/Assets/RuntimeTests/Gameplay/Helpers/GameplayMovementHelper.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/GameplayMovementHelper.cs
@@ -6,18 +6,46 @@ namespace RuntimeTests.Gameplay.Helpers
 {
     public class GameplayMovementHelper
     {
+        private readonly TestInputProvider input;
+
+        public GameplayMovementHelper(TestInputProvider inputProvider)
+        {
+            input = inputProvider;
+        }
+        
         public IEnumerator MovePlayerToPosition(PlayerController player, Vector3 targetPos, float speed = 5f, float threshold = 0.2f, float timeout = 5f)
         {
+            player.input = input;
+            
             var elapsed = 0f;
-            while (Vector3.Distance(player.transform.position, targetPos) > threshold && elapsed < timeout)
+            while (Vector3.Distance(player.transform.position, targetPos) > threshold)
             {
+                if (elapsed >= timeout)
+                {
+                    Debug.LogError("MovePlayerToPosition: Timed out before reaching target position");
+                }
+                
                 var direction = (targetPos - player.transform.position).normalized;
-                player.input = new TestInputProvider(direction.x, false, false);
+                input.SetHorizontal(direction.x);
                 elapsed += Time.deltaTime;
                 yield return null;
             }
 
-            player.input = new TestInputProvider(0, false, false);
+            input.ClearInput();
+        }
+
+        public IEnumerator MovePlayerForSeconds(PlayerController player, Vector3 direction, float time, float speed = 5)
+        {
+            player.input = input;
+            var elapsed = 0f;
+            while (elapsed < time)
+            {
+                input.SetHorizontal(direction.x);
+                elapsed += Time.deltaTime;
+                yield return null;
+            }
+            
+            input.ClearInput();
         }
 
         public void MoveEnemyAlongPatrol(EnemyController enemy, PatrolPath path, float speed = 2f)

--- a/Assets/RuntimeTests/Gameplay/Helpers/GameplayMovementHelper.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/GameplayMovementHelper.cs
@@ -48,7 +48,7 @@ namespace RuntimeTests.Gameplay.Helpers
             input.ClearInput();
         }
 
-        public void MoveEnemyAlongPatrol(EnemyController enemy, PatrolPath path, float speed = 2f)
+        public void MoveEnemyAlongPatrol(EnemyController enemy, PatrolPath path, float speed = 5f)
         {
             path.CreateMover(speed);
             enemy.path = path;

--- a/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
@@ -1,4 +1,6 @@
+using Platformer.Core;
 using Platformer.Mechanics;
+using Platformer.Model;
 using RuntimeTests.Gameplay.Data;
 using UnityEngine;
 
@@ -43,7 +45,9 @@ namespace RuntimeTests.Gameplay.Helpers
             var gameObj = Object.Instantiate(prefab, position, Quaternion.identity);
             gameObj.name = "Player_TEST";
             gameObj.AddComponent<AudioListener>(); // stops complaining about no listeners in scene during test
-            return gameObj.GetComponent<PlayerController>();
+            var controller = gameObj.GetComponent<PlayerController>();
+            Simulation.GetModel<PlatformerModel>().player = controller;
+            return controller;
         }
 
         /// <summary>

--- a/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
@@ -7,17 +7,28 @@ namespace RuntimeTests.Gameplay.Helpers
     public class GameplayTestSpawner
     {
         /// <summary>
+        /// Spawn game object with ground collider of specific size for tests
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="size"></param>
+        /// <returns></returns>
+        public GameObject SpawnGround(Vector3 position, Vector2 size)
+        {
+            var gameObj = new GameObject("Ground_TEST");
+            var groundCollider = gameObj.AddComponent<BoxCollider2D>();
+            groundCollider.size = size;
+            gameObj.transform.position = position;
+            return gameObj;
+        }
+        
+        /// <summary>
         /// Spawns game object with ground collider 100x1 for tests
         /// </summary>
         /// <param name="position"></param>
         /// <returns></returns>
         public GameObject SpawnGround(Vector3 position)
         {
-            var gameObj = new GameObject("Ground_TEST");
-            var groundCollider = gameObj.AddComponent<BoxCollider2D>();
-            groundCollider.size = new Vector2(100, 1);
-            gameObj.transform.position = position;
-            return gameObj;
+            return SpawnGround(position, new Vector2(100, 1));
         }
         
         /// <summary>

--- a/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
@@ -85,7 +85,9 @@ namespace RuntimeTests.Gameplay.Helpers
             token.idleAnimation = new [] {dummySprite};
             token.collectedAnimation = new[] {dummySprite};
             token.sprites = token.idleAnimation;
-                
+
+            token.tokenCollectAudio = CreateDummyAudioClip();
+            
             gameObj.transform.position = position;
             return token;
         }
@@ -145,6 +147,15 @@ namespace RuntimeTests.Gameplay.Helpers
             gameObj.transform.position = position;
             
             return gameObj.AddComponent<DeathZone>();
+        }
+
+        /// <summary>
+        /// Create dummy audio clip to avoid programmatically created objects raising nullrefs on PlayAudio calls
+        /// </summary>
+        /// <returns></returns>
+        public AudioClip CreateDummyAudioClip()
+        {
+            return AudioClip.Create("TestClip", 44100, 1, 44100, false);
         }
     }
 }

--- a/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
@@ -115,7 +115,6 @@ namespace RuntimeTests.Gameplay.Helpers
         /// </summary>
         /// <param name="startPos"></param>
         /// <param name="endPos"></param>
-        /// <returns></returns>
         public PatrolPath CreateEnemyPath(Vector2 startPos, Vector2 endPos)
         {
             var gameObj = new GameObject("PatrolPath_TEST");
@@ -126,6 +125,20 @@ namespace RuntimeTests.Gameplay.Helpers
             path.endPosition = endPos;
 
             return path;
+        }
+
+        /// <summary>
+        /// Create death zone at specified position of specified size
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="size"></param>
+        public DeathZone CreateDeathZone(Vector3 position, Vector2 size)
+        {
+            var gameObj = new GameObject("DeathZone_TEST");
+            var collider = gameObj.AddComponent<BoxCollider2D>();
+            collider.isTrigger = true;
+            
+            return gameObj.AddComponent<DeathZone>();
         }
     }
 }

--- a/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
@@ -137,6 +137,8 @@ namespace RuntimeTests.Gameplay.Helpers
             var gameObj = new GameObject("DeathZone_TEST");
             var collider = gameObj.AddComponent<BoxCollider2D>();
             collider.isTrigger = true;
+            collider.size = size;
+            gameObj.transform.position = position;
             
             return gameObj.AddComponent<DeathZone>();
         }

--- a/Assets/RuntimeTests/Gameplay/Helpers/GameplayWaitHelper.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/GameplayWaitHelper.cs
@@ -133,5 +133,17 @@ namespace RuntimeTests.Gameplay.Helpers
                 Debug.LogError($"WaitForContactWith: No trigger entered with {gameObject.name} after {timeout} seconds");
             }
         }
+
+        public IEnumerator WaitUntilPlayerDeath(PlayerController player, float timeout = 5f)
+        {
+            var elapsed = 0f;
+            while (player.health.IsAlive && elapsed < timeout)
+            {
+                elapsed += Time.deltaTime;
+                yield return null;
+            }
+            
+            
+        }
     }
 }

--- a/Assets/RuntimeTests/Gameplay/Helpers/GameplayWaitHelper.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/GameplayWaitHelper.cs
@@ -1,6 +1,8 @@
 using System.Collections;
 using Platformer.Mechanics;
+using RuntimeTests.Core;
 using UnityEngine;
+using static RuntimeTests.Core.TestCollisionListener2D;
 
 namespace RuntimeTests.Gameplay.Helpers
 {
@@ -36,6 +38,99 @@ namespace RuntimeTests.Gameplay.Helpers
             if (Vector2.Distance(obj1.transform.position, obj2.transform.position) >= threshold)
             {
                 Debug.LogError("Timeout: objects never overlap within threshold.");
+            }
+        }
+
+        public IEnumerator WaitForContactWith(GameObject current, GameObject target, ContactType contactType, float timeout = 5f)
+        {
+            if (current == null || target == null)
+            {
+                Debug.LogError("WaitForContactWith: Current or Target objects are null");
+                yield break;
+            }
+
+            var triggered = false;
+            var collided = false;
+
+            var listener = current.AddComponent<TestCollisionListener2D>();
+
+            listener.OnTriggerEntered += other =>
+            {
+                if (other == target) triggered = true;
+            };
+            listener.OnCollisionEntered += other =>
+            {
+                if (other == target) collided = true;
+            };
+
+            var elapsed = 0f;
+            try
+            {
+                yield return new WaitUntil(() =>
+                {
+                    elapsed += Time.deltaTime;
+                    return contactType switch
+                    {
+                        ContactType.Trigger => triggered,
+                        ContactType.Collision => collided,
+                        ContactType.Any => triggered || collided,
+                        _ => false
+                    } || elapsed > timeout;
+                });
+            }
+            finally
+            {
+                Object.Destroy(listener);
+            }
+
+            if ((contactType == ContactType.Trigger && !triggered) ||
+                (contactType == ContactType.Collision && !triggered) ||
+                (contactType == ContactType.Any && !(triggered || collided)))
+            {
+                Debug.LogError($"WaitForContactWith: No trigger entered with {target.name} after {timeout} seconds");
+            }
+        }
+
+        public IEnumerator WaitForAnyContact(GameObject gameObject, ContactType contactType, float timeout = 5f)
+        {
+            if (gameObject == null)
+            {
+                Debug.LogError("WaitForAnyContact: Current object is null");
+                yield break;
+            }
+
+            var triggered = false;
+            var collided = false;
+
+            var listener = gameObject.AddComponent<TestCollisionListener2D>();
+            listener.OnTriggerEntered += _ => triggered = true;
+            listener.OnCollisionEntered += _ => collided = true;
+
+            var elapsed = 0f;
+            try
+            {
+                yield return new WaitUntil(() =>
+                {
+                    elapsed += Time.deltaTime;
+                    return contactType switch
+                    {
+                        ContactType.Trigger => triggered,
+                        ContactType.Collision => collided,
+                        ContactType.Any => triggered || collided,
+                        _ => false
+                    } || elapsed > timeout;
+                });
+            }
+            finally
+            {
+                Object.Destroy(listener);
+            }
+
+            if ((contactType == ContactType.Trigger && !triggered) ||
+                (contactType == ContactType.Collision && !triggered) ||
+                (contactType == ContactType.Any && !(triggered || collided)))
+            {
+                Debug.LogError($"WaitForContactWith: No trigger entered with {gameObject.name} after {timeout} seconds");
             }
         }
     }

--- a/Assets/RuntimeTests/Gameplay/Helpers/TestInputProvider.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/TestInputProvider.cs
@@ -4,21 +4,35 @@ namespace RuntimeTests.Gameplay.Helpers
 {
     public class TestInputProvider : IPlayerInput
     {
-        private readonly float horizontal;
-        private readonly bool jumpPressed;
-        private readonly bool jumpReleased;
-
-        public TestInputProvider(float h, bool pressed, bool released)
-        {
-            horizontal = h;
-            jumpPressed = pressed;
-            jumpReleased = released;
-        }
-
+        private float horizontal;
+        private bool jumpPressed;
+        private bool jumpReleased;
+        
         public float Horizontal() => horizontal;
 
         public bool JumpPressed() => jumpPressed;
 
         public bool JumpReleased() => jumpReleased;
+
+        public void SetHorizontal(float value) => horizontal = value;
+
+        public void PressJump()
+        {
+            jumpPressed = true;
+            jumpReleased = false;
+        }
+
+        public void ReleaseJump()
+        {
+            jumpPressed = false;
+            jumpReleased = true;
+        }
+
+        public void ClearInput()
+        {
+            jumpPressed = false;
+            jumpReleased = false;
+            horizontal = 0;
+        }
     }
 }

--- a/Assets/RuntimeTests/Gameplay/PlayerDeathTests.cs
+++ b/Assets/RuntimeTests/Gameplay/PlayerDeathTests.cs
@@ -1,5 +1,7 @@
 using System.Collections;
 using NUnit.Framework;
+using Platformer.Mechanics;
+using RuntimeTests.Core;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -7,21 +9,31 @@ namespace RuntimeTests.Gameplay
 {
     public class PlayerDeathTests : GameplayTestBase
     {
-        // A Test behaves as an ordinary method
-        [Test]
-        public void PlayerDeathTestsSimplePasses()
+        private PlayerController player;
+        
+        [SetUp]
+        public override void SetUp()
         {
-            // Use the Assert class to test conditions
+            base.SetUp();
+            
+            player = testSpawner.SpawnPlayer(new Vector3(0, 0));
         }
-    
-        // A UnityTest behaves like a coroutine in Play Mode. In Edit Mode you can use
-        // `yield return null;` to skip a frame.
+        
         [UnityTest]
-        public IEnumerator PlayerDeathTestsWithEnumeratorPasses()
+        public IEnumerator DeathZoneBelowPlayer_PlayerFallsIntoZone_PlayerDeath()
         {
-            // Use the Assert class to test conditions.
-            // Use yield to skip a frame.
-            yield return null;
+            var deathZone = testSpawner.CreateDeathZone(new Vector3(0, -5), new Vector2(6,1));
+
+            yield return waitHelper.WaitForContactWith(
+                player.gameObject, 
+                deathZone.gameObject, 
+                TestCollisionListener2D.ContactType.Trigger);
+
+            // Assert with timeout for non hanging tests, safer than WaitUntil()
+            Assert.That(
+                () => !player.health.IsAlive, 
+                Is.True.After(5000, 100), 
+                "Expected player to die within 5s of falling into death zone"); 
         }
     }
 }

--- a/Assets/RuntimeTests/Gameplay/PlayerDeathTests.cs
+++ b/Assets/RuntimeTests/Gameplay/PlayerDeathTests.cs
@@ -10,30 +10,46 @@ namespace RuntimeTests.Gameplay
     public class PlayerDeathTests : GameplayTestBase
     {
         private PlayerController player;
-        
+
         [SetUp]
         public override void SetUp()
         {
             base.SetUp();
-            
+
             player = testSpawner.SpawnPlayer(new Vector3(0, 0));
         }
-        
+
         [UnityTest]
         public IEnumerator DeathZoneBelowPlayer_PlayerFallsIntoZone_PlayerDeath()
         {
-            var deathZone = testSpawner.CreateDeathZone(new Vector3(0, -5), new Vector2(6,1));
+            var deathZone = testSpawner.CreateDeathZone(new Vector3(0, -5), new Vector2(6, 1));
 
             yield return waitHelper.WaitForContactWith(
-                player.gameObject, 
-                deathZone.gameObject, 
+                player.gameObject,
+                deathZone.gameObject,
                 TestCollisionListener2D.ContactType.Trigger);
 
             // Assert with timeout for non hanging tests, safer than WaitUntil()
             Assert.That(
-                () => !player.health.IsAlive, 
-                Is.True.After(5000, 100), 
-                "Expected player to die within 5s of falling into death zone"); 
+                () => !player.health.IsAlive,
+                Is.True.After(5000, 100),
+                "Expected player to die within 5s of falling into death zone");
+        }
+
+        [UnityTest]
+        public IEnumerator PlayerInEnemyPath_EnemyCollidesWithPlayer_PlayerDeath()
+        {
+            testSpawner.SpawnGround(new Vector3(0, -1f));
+            var enemy = testSpawner.SpawnEnemy(new Vector3(3, 0));
+            var path = testSpawner.CreateEnemyPath(new Vector2(-2, 0), new Vector2(3, 0));
+            movementHelper.MoveEnemyAlongPatrol(enemy, path);
+
+            yield return waitHelper.WaitUntilPlayerDeath(player);
+
+            Assert.That(
+                () => !player.health.IsAlive,
+                Is.True.After(5000, 100),
+                "Expected player to die within 5s of enemy collision");
         }
     }
 }

--- a/Assets/RuntimeTests/Gameplay/PlayerDeathTests.cs
+++ b/Assets/RuntimeTests/Gameplay/PlayerDeathTests.cs
@@ -5,7 +5,7 @@ using UnityEngine.TestTools;
 
 namespace RuntimeTests.Gameplay
 {
-    public class PlayerDeathTests
+    public class PlayerDeathTests : GameplayTestBase
     {
         // A Test behaves as an ordinary method
         [Test]

--- a/Assets/RuntimeTests/RuntimeTests.asmdef
+++ b/Assets/RuntimeTests/RuntimeTests.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "GameClient"
+        "GameClient",
+        "Unity.Cinemachine"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Scripts/Core/Simulation.cs
+++ b/Assets/Scripts/Core/Simulation.cs
@@ -134,6 +134,15 @@ namespace Platformer.Core
             }
             return eventQueue.Count;
         }
+
+#if UNITY_INCLUDE_TESTS
+        // required to unload cached events - some events hold cached instance fields
+        // these instance fields leak between tests when run sequentially, can cause missing ref exceptions
+        public static void ClearPools()
+        {
+            eventPools.Clear(); 
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
Coverage for end to end death flow for player. Added additional test helpers for future coverage too.

Added:
- Helpers for waiting on collision in UnityTests.
- `PlayerDeathTests` for dying against DeathZone (fall damage) & Enemy Collision

Changed:
- `TestInputProvider` now reusable. `GameplayMovementHelper` refactored to allow better movement
- Added new elements to `GameplayTestSpawner` for various helper methods in the death tests

Fixed:
- `Simulation.ClearPools` exists solely as a test method to allow clearing of cached events during tests. Some tests being run sequentially would cause issues with cached instance fields for the PlatformerModel, where it was initialised outside of the Execute scope. This meant it would leak between tests, and hold refs to the player etc from the last test (which had been since destroyed).