### PR TITLE
Add: enemy path tests

### DIFF
--- a/Assets/Editor/Utils.meta
+++ b/Assets/Editor/Utils.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c12403c66c404b9fa14066e7abcaa222
+timeCreated: 1746044556

--- a/Assets/Editor/Utils/EditorPathValidatorUtil.cs
+++ b/Assets/Editor/Utils/EditorPathValidatorUtil.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Platformer.Mechanics;
+using UnityEditor;
+using UnityEngine;
+using Utils;
+using Object = UnityEngine.Object;
+using PathValidationError = Utils.PathValidator.PathValidationError;
+
+namespace Platformer.Utils
+{
+    public static class EditorPathValidatorUtil
+    {
+        [MenuItem("Tools/Validate Paths In Current Scene")]
+        public static void ValidatePathsInScene()
+        {
+            var paths = Object.FindObjectsByType<PatrolPath>(FindObjectsSortMode.None);
+            var invalidPaths = new Dictionary<GameObject, PathValidationError>();
+
+            foreach (var path in paths)
+            {
+                var originalName = path.gameObject.name;
+                originalName = originalName.Replace("[Blocked] ", "").Replace("[MissingGround] ", "");
+
+                PathValidator.ValidatePathByTile(path, error =>
+                {
+                    invalidPaths.TryAdd(path.gameObject, error);
+                });
+
+                if (invalidPaths.TryGetValue(path.gameObject, out var errorType))
+                {
+                    var prefix = errorType switch
+                    {
+                        PathValidationError.Blocked => "[Blocked] ",
+                        PathValidationError.MissingGround => "[MissingGround]",
+                        _ => "[Invalid] "
+                    };
+                    path.gameObject.name = prefix + originalName;
+                }
+                else
+                {
+                    path.gameObject.name = originalName;
+                }
+            }
+
+            if (invalidPaths.Count > 0)
+            {
+                foreach (var kvp in invalidPaths)
+                {
+                    var reason = kvp.Value == PathValidationError.Blocked ? "Blocked by tile" : "Missing ground below";
+                    Debug.LogError($"[PATH VALIDATOR] - Invalid Path: {kvp.Key.name} - {reason}", kvp.Key);
+                }
+
+                Selection.objects = invalidPaths.Keys.ToArray();
+                EditorUtility.DisplayDialog("PATH VALIDATOR",
+                    $"Highlighted {invalidPaths.Count} invalid patrol paths in scene", "Continue");
+                Debug.Log($"[PATH VALIDATOR] - Highlighted {invalidPaths.Count} invalid patrol paths in scene");
+            }
+            else
+            {
+                EditorUtility.DisplayDialog("PATH VALIDATOR", "All paths valid!", "Continue");
+            }
+        }
+    }
+}

--- a/Assets/Editor/Utils/EditorPathValidatorUtil.cs.meta
+++ b/Assets/Editor/Utils/EditorPathValidatorUtil.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 08edccec994c49bd9c9455aa79624f9f
+timeCreated: 1746044601

--- a/Assets/RuntimeTests/Core/TestBase.cs
+++ b/Assets/RuntimeTests/Core/TestBase.cs
@@ -1,19 +1,20 @@
-using NUnit.Framework;
+using System.Collections;
+using UnityEngine.TestTools;
 
 namespace RuntimeTests.Core
 {
     public abstract class TestBase
     {
-        [SetUp]
-        public virtual void SetUp()
+        [UnitySetUp]
+        public virtual IEnumerator SetUp()
         {
-            
+            yield return null;
         }
 
-        [TearDown]
-        public virtual void TearDown()
+        [UnityTearDown]
+        public virtual IEnumerator TearDown()
         {
-            
+            yield return null;
         }
         
     }

--- a/Assets/RuntimeTests/Gameplay/CollectableTests.cs
+++ b/Assets/RuntimeTests/Gameplay/CollectableTests.cs
@@ -1,9 +1,7 @@
 using System.Collections;
 using NUnit.Framework;
 using Platformer.Mechanics;
-using RuntimeTests.Gameplay.Helpers;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 
 namespace RuntimeTests.Gameplay
@@ -20,10 +18,10 @@ namespace RuntimeTests.Gameplay
         /// <summary>
         /// Always create token for new test at the same position
         /// </summary>
-        [SetUp]
-        public override void SetUp()
+        [UnitySetUp]
+        public override IEnumerator SetUp()
         {
-            base.SetUp();
+            yield return base.SetUp();
             
             testSpawner.SpawnGround(new Vector3(0, -1f, 0));
             collectableToken = testSpawner.SpawnToken(collectablePosition);

--- a/Assets/RuntimeTests/Gameplay/Data/GameDataPaths.cs
+++ b/Assets/RuntimeTests/Gameplay/Data/GameDataPaths.cs
@@ -10,7 +10,7 @@ namespace RuntimeTests.Gameplay.Data
 
         public class Scenes
         {
-            public const string MainScene = "Scenes/MainScene";
+            public const string MainScene = "Scenes/SampleScene";
         }
     }
 }

--- a/Assets/RuntimeTests/Gameplay/Data/GameDataPaths.cs
+++ b/Assets/RuntimeTests/Gameplay/Data/GameDataPaths.cs
@@ -2,7 +2,15 @@ namespace RuntimeTests.Gameplay.Data
 {
     public static class GameDataPaths
     {
-        public const string PlayerPrefab = "Prefabs/Player";
-        public const string EnemyPrefab = "Prefabs/Enemy";
+        public class Prefabs
+        {
+            public const string PlayerPrefab = "Prefabs/Player";
+            public const string EnemyPrefab = "Prefabs/Enemy";
+        }
+
+        public class Scenes
+        {
+            public const string MainScene = "Scenes/MainScene";
+        }
     }
 }

--- a/Assets/RuntimeTests/Gameplay/Data/GameDataPaths.cs
+++ b/Assets/RuntimeTests/Gameplay/Data/GameDataPaths.cs
@@ -10,7 +10,7 @@ namespace RuntimeTests.Gameplay.Data
 
         public class Scenes
         {
-            public const string MainScene = "Scenes/SampleScene";
+            public const string MainScene = "Assets/Scenes/SampleScene.unity";
         }
     }
 }

--- a/Assets/RuntimeTests/Gameplay/EnemyPathTests.cs
+++ b/Assets/RuntimeTests/Gameplay/EnemyPathTests.cs
@@ -1,27 +1,74 @@
 using System.Collections;
+using System.Collections.Generic;
 using NUnit.Framework;
+using Platformer.Mechanics;
+using RuntimeTests.Gameplay.Data;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
+using UnityEngine.Tilemaps;
+using Utils;
+using Object = UnityEngine.Object;
 
 namespace RuntimeTests.Gameplay
 {
     public class EnemyPathTests : GameplayTestBase
     {
-        // A Test behaves as an ordinary method
-        [Test]
-        public void EnemyPathTestsSimplePasses()
+        [SetUp]
+        public override void SetUp()
         {
-            // Use the Assert class to test conditions
+            base.SetUp();
+            SceneManager.LoadScene(GameDataPaths.Scenes.MainScene);
         }
 
-        // A UnityTest behaves like a coroutine in Play Mode. In Edit Mode you can use
-        // `yield return null;` to skip a frame.
-        [UnityTest]
-        public IEnumerator EnemyPathTestsWithEnumeratorPasses()
+        [TearDown]
+        public override void TearDown()
         {
-            // Use the Assert class to test conditions.
-            // Use yield to skip a frame.
+            var scene = SceneManager.GetSceneByPath(GameDataPaths.Scenes.MainScene);
+            if (scene.isLoaded)
+            {
+                var unload = SceneManager.UnloadSceneAsync(scene);
+                while (unload is {isDone: false}) { }
+            }
+            base.TearDown();
+        }
+
+        [UnityTest]
+        public IEnumerator LoadMainScene_ValidateAllPatrolPaths_PatrolPathsValid()
+        {
             yield return null;
+            
+            var enemyHeight = Object.FindFirstObjectByType<EnemyController>().gameObject.transform.localScale.y;
+            var paths = Object.FindObjectsByType<PatrolPath>(FindObjectsSortMode.None);
+            var collider = Object.FindFirstObjectByType<TilemapCollider2D>();
+            
+            Assert.IsNotNull(collider, "Expected collider in scene for level");
+            Assert.IsNotEmpty(paths, "Expected PatrolPaths in scene");
+
+            var invalid = new Dictionary<PatrolPath, (PathValidator.PathValidationError, IReadOnlyList<Vector2>)>();
+            
+            foreach (var path in paths)
+            {
+                var pathValid = PathValidator.ValidatePath(
+                    path,
+                    collider,
+                    (error, points) => invalid[path] = (error, points),
+                    enemyHeight);
+                if(!pathValid) continue;
+            }
+
+            if (invalid.Count > 0)
+            {
+                foreach (var kvp in invalid)
+                {
+                    var point = string.Join(", ", kvp.Value.Item2);
+                    Debug.LogError(
+                        $"Path: '{kvp.Key.name}' -> {kvp.Value.Item1} at {point}");
+                }
+                Assert.Fail($"{invalid.Count} patrol path(s) are invalid, see test log for info.");
+            }
+            
+            Assert.That(invalid.Count == 0);
         }
     }
 

--- a/Assets/RuntimeTests/Gameplay/EnemyPathTests.cs
+++ b/Assets/RuntimeTests/Gameplay/EnemyPathTests.cs
@@ -12,20 +12,20 @@ using Object = UnityEngine.Object;
 
 namespace RuntimeTests.Gameplay
 {
-    public class EnemyPathTests : GameplayTestBase
+    public class EnemyPathTests : TestBase
     {
-        [SetUp]
-        public override void SetUp()
+        [UnitySetUp]
+        public override IEnumerator SetUp()
         {
-            base.SetUp();
+            yield return base.SetUp();
             SceneManager.LoadScene(GameDataPaths.Scenes.MainScene);
         }
 
-        [TearDown]
-        public override void TearDown()
+        [UnityTearDown]
+        public override IEnumerator TearDown()
         {
             var scene = SceneManager.GetSceneByPath(GameDataPaths.Scenes.MainScene);
-            if (scene.isLoaded)
+            yield return base.TearDown();
             {
                 var unload = SceneManager.UnloadSceneAsync(scene);
                 while (unload is {isDone: false}) { }

--- a/Assets/RuntimeTests/Gameplay/EnemyPathTests.cs
+++ b/Assets/RuntimeTests/Gameplay/EnemyPathTests.cs
@@ -2,9 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Platformer.Mechanics;
+using RuntimeTests.Core;
 using RuntimeTests.Gameplay.Data;
+using RuntimeTests.Gameplay.Helpers;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using UnityEngine.Tilemaps;
 using Utils;
@@ -18,19 +19,14 @@ namespace RuntimeTests.Gameplay
         public override IEnumerator SetUp()
         {
             yield return base.SetUp();
-            SceneManager.LoadScene(GameDataPaths.Scenes.MainScene);
+            yield return TestSceneLoader.LoadMainScene();
         }
 
         [UnityTearDown]
         public override IEnumerator TearDown()
         {
-            var scene = SceneManager.GetSceneByPath(GameDataPaths.Scenes.MainScene);
+            yield return TestSceneLoader.UnloadActiveSceneAndReplaceWithFallback();
             yield return base.TearDown();
-            {
-                var unload = SceneManager.UnloadSceneAsync(scene);
-                while (unload is {isDone: false}) { }
-            }
-            base.TearDown();
         }
 
         [UnityTest]

--- a/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
+++ b/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using NUnit.Framework;
 using Platformer.Core;
 using Platformer.Mechanics;
 using Platformer.Model;
@@ -18,11 +17,13 @@ namespace RuntimeTests.Gameplay
         protected GameplayWaitHelper waitHelper;
         protected TestInputProvider testInput = new ();
         protected GameController gameController;
+
+        protected Scene testScene;
         
-        [SetUp]
-        public override void SetUp()
+        [UnitySetUp]
+        public override IEnumerator SetUp()
         {
-            base.SetUp();
+            yield return base.SetUp();
             
             var spawnPoint = new GameObject("Spawn_TEST");
             spawnPoint.transform.position = Vector3.zero;
@@ -42,8 +43,8 @@ namespace RuntimeTests.Gameplay
             waitHelper = new GameplayWaitHelper();
         }
         
-        [TearDown]
-        public override void TearDown()
+        [UnityTearDown]
+        public override IEnumerator TearDown()
         {
             Simulation.ClearPools();
 
@@ -54,7 +55,8 @@ namespace RuntimeTests.Gameplay
                     Object.DestroyImmediate(obj);
                 }
             }
-            base.TearDown();
+
+            yield return base.TearDown();
         }
     }
 }

--- a/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
+++ b/Assets/RuntimeTests/Gameplay/GameplayTestBase.cs
@@ -3,10 +3,13 @@ using Platformer.Core;
 using Platformer.Mechanics;
 using Platformer.Model;
 using RuntimeTests.Core;
+using RuntimeTests.Gameplay.Data;
 using RuntimeTests.Gameplay.Helpers;
 using Unity.Cinemachine;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
 
 namespace RuntimeTests.Gameplay
 {
@@ -24,6 +27,8 @@ namespace RuntimeTests.Gameplay
         public override IEnumerator SetUp()
         {
             yield return base.SetUp();
+
+            yield return TestSceneLoader.CreateAndSetTestScene(scene => testScene = scene);
             
             var spawnPoint = new GameObject("Spawn_TEST");
             spawnPoint.transform.position = Vector3.zero;
@@ -50,12 +55,17 @@ namespace RuntimeTests.Gameplay
 
             foreach (var obj in Object.FindObjectsByType<GameObject>(FindObjectsInactive.Include, FindObjectsSortMode.None))
             {
-                if (obj.scene.IsValid() && obj.scene.isLoaded)
+                if (obj.scene == testScene && obj.scene.isLoaded)
                 {
                     Object.DestroyImmediate(obj);
                 }
             }
 
+            if (testScene.IsValid() && testScene.isLoaded)
+            {
+                yield return TestSceneLoader.UnloadActiveSceneAndReplaceWithFallback();
+            }
+            
             yield return base.TearDown();
         }
     }

--- a/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/GameplayTestSpawner.cs
@@ -41,7 +41,7 @@ namespace RuntimeTests.Gameplay.Helpers
         /// <param name="position"></param>
         public PlayerController SpawnPlayer(Vector3 position)
         {
-            var prefab = Resources.Load<GameObject>(GameDataPaths.PlayerPrefab);
+            var prefab = Resources.Load<GameObject>(GameDataPaths.Prefabs.PlayerPrefab);
             var gameObj = Object.Instantiate(prefab, position, Quaternion.identity);
             gameObj.name = "Player_TEST";
             gameObj.AddComponent<AudioListener>(); // stops complaining about no listeners in scene during test
@@ -58,7 +58,7 @@ namespace RuntimeTests.Gameplay.Helpers
         /// <param name="position"></param>
         public EnemyController SpawnEnemy(Vector3 position)
         {
-            var prefab = Resources.Load<GameObject>(GameDataPaths.EnemyPrefab);
+            var prefab = Resources.Load<GameObject>(GameDataPaths.Prefabs.EnemyPrefab);
             var gameObj = Object.Instantiate(prefab, position, Quaternion.identity);
             gameObj.name = "Enemy_TEST";
             return gameObj.GetComponent<EnemyController>();

--- a/Assets/RuntimeTests/Gameplay/Helpers/TestSceneLoader.cs
+++ b/Assets/RuntimeTests/Gameplay/Helpers/TestSceneLoader.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections;
+using RuntimeTests.Gameplay.Data;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace RuntimeTests.Gameplay.Helpers
+{
+    public static class TestSceneLoader
+    {
+        public static IEnumerator UnloadActiveSceneAndReplaceWithFallback()
+        {
+            var scene = SceneManager.GetSceneByPath(GameDataPaths.Scenes.MainScene);
+            if (!scene.IsValid() || !scene.isLoaded)
+            {
+                yield break;
+            }
+
+            if (SceneManager.sceneCount == 1 && SceneManager.GetSceneAt(0) == scene)
+            {
+                var fallback = SceneManager.CreateScene("FallbackScene_" + Guid.NewGuid());
+                SceneManager.SetActiveScene(fallback);
+                yield return null;
+            }
+            
+            var unload = SceneManager.UnloadSceneAsync(scene);
+            if(unload != null)
+            {
+                yield return new WaitUntil(() => unload.isDone);
+            }
+        }
+
+        public static IEnumerator LoadMainScene()
+        {
+            var load = SceneManager.LoadSceneAsync(GameDataPaths.Scenes.MainScene, LoadSceneMode.Single);
+            yield return new WaitUntil(() => load.isDone);
+
+            var loadedScene = SceneManager.GetSceneByPath(GameDataPaths.Scenes.MainScene);
+            if (!loadedScene.IsValid() || !loadedScene.isLoaded)
+            {
+                Debug.LogError($"Main scene couldn't be loaded from {GameDataPaths.Scenes.MainScene}");
+                yield break;
+            }
+
+            SceneManager.SetActiveScene(loadedScene);
+        }
+
+        public static IEnumerator CreateAndSetTestScene(Action<Scene> onSceneCreated)
+        {
+            var scene = SceneManager.CreateScene("TestScene_" + Guid.NewGuid());
+            SceneManager.SetActiveScene(scene);
+            onSceneCreated?.Invoke(scene);
+            yield return null;
+        }
+    }
+}

--- a/Assets/RuntimeTests/Gameplay/Helpers/TestSceneLoader.cs.meta
+++ b/Assets/RuntimeTests/Gameplay/Helpers/TestSceneLoader.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9521bb51e0c54a76a970d002703b712b
+timeCreated: 1746132023

--- a/Assets/RuntimeTests/Gameplay/PlayerDeathTests.cs
+++ b/Assets/RuntimeTests/Gameplay/PlayerDeathTests.cs
@@ -11,10 +11,10 @@ namespace RuntimeTests.Gameplay
     {
         private PlayerController player;
 
-        [SetUp]
-        public override void SetUp()
+        [UnitySetUp]
+        public override IEnumerator SetUp()
         {
-            base.SetUp();
+            yield return base.SetUp();
 
             player = testSpawner.SpawnPlayer(new Vector3(0, 0));
         }

--- a/Assets/Scripts/Utils.meta
+++ b/Assets/Scripts/Utils.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b8bb322fb3044f18bb59de67feb46826
+timeCreated: 1746043262

--- a/Assets/Scripts/Utils/PathValidator.cs
+++ b/Assets/Scripts/Utils/PathValidator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Platformer.Mechanics;
 using UnityEngine;
 using UnityEngine.Tilemaps;
@@ -38,14 +39,25 @@ namespace Utils
             var samples = Mathf.CeilToInt(Vector2.Distance(start, end));
             var rayLength = enemyHeight + 0.01f;
 
+            var hitBuffer = new List<RaycastHit2D>();
+            var filter = new ContactFilter2D().NoFilter();
+            
             for (var i = 0; i <= samples; i++)
             {
                 var point = Vector2.Lerp(start, end, i / (float) samples);
                 var origin = point + Vector2.up * 0.01f;
+                var hitCount = Physics2D.Raycast(origin, Vector2.down, filter, hitBuffer, rayLength);
 
-                var hit = Physics2D.Raycast(origin, Vector2.down, rayLength);
-                
-                if (hit.collider == null || hit.collider != collider)
+                var hitTilemap = false;
+
+                for (var h = 0; h < hitCount; h++)
+                {
+                    if (hitBuffer[h].collider != collider) continue;
+                    hitTilemap = true;
+                    break;
+                }
+
+                if (!hitTilemap)
                 {
                     Debug.DrawLine(point, origin + Vector2.down * rayLength, Color.yellow, 60f);
                     missingGroundPoints.Add(point);
@@ -54,7 +66,15 @@ namespace Utils
 
             return missingGroundPoints.Count == 0;
         }
-
+        
+        /// <summary>
+        /// Validates an enemy PatrolPath for obstructions & missing ground collision below
+        /// </summary>
+        /// <param name="path">Path to validate</param>
+        /// <param name="collider">Collider to check for</param>
+        /// <param name="onError">Error callback, raised as (path error type, list of affected points in path).</param>
+        /// <param name="enemyHeight">Height of the enemy used for the path (to easily check the ground is close enough to path)</param>
+        /// <returns></returns>
         public static bool ValidatePath(PatrolPath path, TilemapCollider2D collider,  Action<PathValidationError, IReadOnlyList<Vector2>> onError, float enemyHeight = 1f)
         {
             var obstructed = IsObstructed(path, collider, out var obstructedPoints);

--- a/Assets/Scripts/Utils/PathValidator.cs
+++ b/Assets/Scripts/Utils/PathValidator.cs
@@ -45,7 +45,7 @@ namespace Utils
 
                 var hit = Physics2D.Raycast(origin, Vector2.down, rayLength);
                 
-                if (hit.collider == null || !hit.collider == collider)
+                if (hit.collider == null || hit.collider != collider)
                 {
                     Debug.DrawLine(point, origin + Vector2.down * rayLength, Color.yellow, 60f);
                     missingGroundPoints.Add(point);
@@ -69,7 +69,7 @@ namespace Utils
                 onError?.Invoke(PathValidationError.MissingGround, missingGroundPoints);
             }
             
-            return obstructed || missingGround;
+            return !(obstructed || missingGround);
         }
 
         public enum PathValidationError

--- a/Assets/Scripts/Utils/PathValidator.cs
+++ b/Assets/Scripts/Utils/PathValidator.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Platformer.Mechanics;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+
+namespace Utils
+{
+    public static class PathValidator
+    {
+        public static bool ValidatePathSampled(PatrolPath path, int sampleCount, Action<PathValidationError> onPathError)
+        {
+            var pathStart = path.transform.TransformPoint(path.startPosition);
+            var pathEnd = path.transform.TransformPoint(path.endPosition);
+            var direction = (pathEnd - pathStart).normalized;
+            var distance = Vector2.Distance(pathStart, pathEnd);
+
+            var hit = Physics2D.Raycast(pathStart, direction, distance);
+            if (hit.collider is TilemapCollider2D)
+            {
+                onPathError?.Invoke(PathValidationError.Blocked);
+                return false;
+            }
+            
+            for (var i = 0; i <= sampleCount; i++)
+            {
+                var t = i / (float)sampleCount;
+                var pos = Vector2.Lerp(pathStart, pathEnd, t);
+                var rayStart = pos + Vector2.up * 0.1f;
+                var groundHit = Physics2D.Raycast(rayStart, Vector2.down, 1.5f);
+                var isOverGround = groundHit.collider is TilemapCollider2D;
+                Debug.DrawRay(pos, Vector2.down * 1.5f, isOverGround ? Color.yellow : Color.blue, 60f);
+
+                if (!isOverGround)
+                {
+                    onPathError?.Invoke(PathValidationError.MissingGround);
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public static bool ValidatePathByTile(PatrolPath path, Action<PathValidationError> onPathError)
+        {
+            var start = path.transform.TransformPoint(path.startPosition);
+            var end = path.transform.TransformPoint(path.endPosition);
+            var distance = Vector2.Distance(start, end);
+            var sampleCount = Mathf.CeilToInt(distance);
+            return ValidatePathSampled(path, sampleCount, onPathError);
+        }
+
+        public enum PathValidationError
+        {
+            Blocked, 
+            MissingGround
+        }
+    }
+}

--- a/Assets/Scripts/Utils/PathValidator.cs
+++ b/Assets/Scripts/Utils/PathValidator.cs
@@ -9,50 +9,66 @@ namespace Utils
 {
     public static class PathValidator
     {
-        public static bool ValidatePathSampled(PatrolPath path, int sampleCount, Action<PathValidationError> onPathError)
-        {
-            var pathStart = path.transform.TransformPoint(path.startPosition);
-            var pathEnd = path.transform.TransformPoint(path.endPosition);
-            var direction = (pathEnd - pathStart).normalized;
-            var distance = Vector2.Distance(pathStart, pathEnd);
-
-            var hit = Physics2D.Raycast(pathStart, direction, distance);
-            if (hit.collider is TilemapCollider2D)
-            {
-                onPathError?.Invoke(PathValidationError.Blocked);
-                return false;
-            }
-            
-            for (var i = 0; i <= sampleCount; i++)
-            {
-                var t = i / (float)sampleCount;
-                var pos = Vector2.Lerp(pathStart, pathEnd, t);
-                var rayStart = pos + Vector2.up * 0.1f;
-                var groundHit = Physics2D.Raycast(rayStart, Vector2.down, 1.5f);
-                var isOverGround = groundHit.collider is TilemapCollider2D;
-                Debug.DrawRay(pos, Vector2.down * 1.5f, isOverGround ? Color.yellow : Color.blue, 60f);
-
-                if (!isOverGround)
-                {
-                    onPathError?.Invoke(PathValidationError.MissingGround);
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        public static bool ValidatePathByTile(PatrolPath path, Action<PathValidationError> onPathError)
+        public static bool IsObstructed(PatrolPath path, TilemapCollider2D collider)
         {
             var start = path.transform.TransformPoint(path.startPosition);
             var end = path.transform.TransformPoint(path.endPosition);
-            var distance = Vector2.Distance(start, end);
-            var sampleCount = Mathf.CeilToInt(distance);
-            return ValidatePathSampled(path, sampleCount, onPathError);
+
+            var samples = Mathf.CeilToInt(Vector2.Distance(start, end));
+
+            for (var i = 0; i <= samples; i++)
+            {
+                var point = Vector2.Lerp(start, end, i / (float) samples);
+                if (collider.OverlapPoint(point))
+                {
+                    Debug.DrawLine(point + Vector2.down * 0.2f, point + Vector2.up * 0.2f, Color.red, 60f);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static bool IsGroundValid(PatrolPath path, TilemapCollider2D collider, float enemyHeight = 1f)
+        {
+            var start = path.transform.TransformPoint(path.startPosition);
+            var end = path.transform.TransformPoint(path.endPosition);
+
+            var samples = Mathf.CeilToInt(Vector2.Distance(start, end));
+
+            for (var i = 0; i <= samples; i++)
+            {
+                var point = Vector2.Lerp(start, end, i / (float) samples);
+                var groundCheck = point + Vector2.down * enemyHeight;
+                if (!collider.OverlapPoint(groundCheck))
+                {
+                    Debug.DrawLine(point, groundCheck, Color.yellow, 60f);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static bool ValidatePath(PatrolPath path, TilemapCollider2D collider,  Action<PathValidationError> onError, float enemyHeight = 1f)
+        {
+            if (IsObstructed(path, collider))
+            {
+                onError?.Invoke(PathValidationError.Obstructed);
+                return false;
+            }
+
+            if (!IsGroundValid(path, collider, enemyHeight))
+            {
+                onError?.Invoke(PathValidationError.MissingGround);
+                return false;
+            }
+
+            return true;
         }
 
         public enum PathValidationError
         {
-            Blocked, 
+            Obstructed, 
             MissingGround
         }
     }

--- a/Assets/Scripts/Utils/PathValidator.cs.meta
+++ b/Assets/Scripts/Utils/PathValidator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f253fe3193ce446aa792eac7801eb5ab
+timeCreated: 1746043273


### PR DESCRIPTION
This adds the ability to validate the enemy pathing system. Validations can be done through editor tools (for level designers to check their work), and to run in tests. Can be run in the Menu `Tools\Level Editor\Validate X...`:
![image](https://github.com/user-attachments/assets/1e670fc3-7139-4719-bcc4-291e172c2d81)


Added:
- `PathValidator` - This gives utils to check if ground is below path, if path is obstructed
- `EditorPathValidatorUtil` - This gives the menu items to test if paths in loaded scene & selected paths are valid. Will log all bad points & paths to the console, as well as rename them in the scene to easily highlight. Draws a debug ray over the affected point for 60s as well.
- 'TestSceneLoader' - Utils for the tests to load/handle scenes in a test safe way. Avoids issues/flaky tests where different scenes are being loaded/unloaded
- `EnemyPathTests` - Added a simple test for the main level scene for valid paths. Not checked - specific scenes for invalid paths being caught in runtime tests. Would be nice to have but not in scope with task time!

Modified:
- `GameplayTestBase`, `CollectableTests`, `PlayerDeathTests` & `TestBase` now all use the PlayMode UnitySetUp & UnityTearDown IEnumerator pattern rather than the NUnit one. This was to allow yield for async scene loads/unloads
- `GameDataPaths` was refactored to allow scenes & prefabs to be scoped within the static path class

Test runs:
Editor tests: 
![image](https://github.com/user-attachments/assets/8c221a9f-c7f1-4f2e-9298-d08527e3b466)
Runtime tests:
![image](https://github.com/user-attachments/assets/78a91b5d-1ec1-49c5-a722-eee39e655371)

